### PR TITLE
Added wheel to requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,6 +10,7 @@ opencv-python
 imageio
 imageio-ffmpeg
 omegaconf
+wheel
 
 torch
 einops


### PR DESCRIPTION
when running 

```
pip install ./diff-gaussian-rasterization
pip install ./simple-knn
```
I got dependency error
`ModuleNotFoundError: No module named 'torch'`
although I had correct torch version installed. Problem was fixed when installing `wheel`.